### PR TITLE
Add finer grained build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,18 @@ cmake_minimum_required(VERSION 3.0)
 
 SET ( LIBNOISE_VERSION "1.0.0-cmake" )
 
+OPTION(BUILD_SHARED_LIBS "Build shared libraries for libnoise" ON)
 OPTION(BUILD_LIBNOISE_DOCUMENTATION "Create doxygen documentation for developers" OFF)
+OPTION(BUILD_LIBNOISE_UTILS "Build utility functions for use with libnoise" ON)
+OPTION(BUILD_LIBNOISE_EXAMPLES "Build libnoise examples" ON)
 
 ADD_SUBDIRECTORY(src)
-ADD_SUBDIRECTORY(noiseutils)
-ADD_SUBDIRECTORY(examples)
+IF (BUILD_LIBNOISE_UTILS)
+    ADD_SUBDIRECTORY(noiseutils)
+ENDIF()
+IF (BUILD_LIBNOISE_EXAMPLES)
+    ADD_SUBDIRECTORY(examples)
+ENDIF()
 ADD_SUBDIRECTORY(doc)
 
 #ADD_SUBDIRECTORY(samples)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,10 +44,12 @@ set(libSrcs ${libSrcs}
     module/voronoi.cpp
 )
 
-IF (WIN32)
-add_library( noise SHARED ${libSrcs} win32/dllmain.cpp)
-ELSE()
-add_library( noise SHARED ${libSrcs} )
+IF(BUILD_SHARED_LIBS)
+    IF (WIN32)
+    add_library( noise SHARED ${libSrcs} win32/dllmain.cpp)
+    ELSE()
+    add_library( noise SHARED ${libSrcs} )
+    ENDIF()
 ENDIF()
 
 add_library( noise-static STATIC ${libSrcs} )


### PR DESCRIPTION
This adds finer grained control over the build parameters for libnoise. For instance, in my consuming application, when I add libnoise via `add_subdirectory` I don't want the extra overhead of building examples or even the utility functions if I don't need them, as I have a bazillion other things that also need to be built.