### PR TITLE
bugfix and optimization only for release-builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(LIBNOISE_VERSION "1.0.0-cmake")
 #----------------------------------------
 # Provide an option for the user to select (default given; otherwhise pass -Doption=ON to cmake)
 option(BUILD_WALL "Build with all warnings enabled" OFF)
-option(BUILD_OPTIMIZED "Build with optimization for speed" OFF)
+option(BUILD_SPEED_OPTIMIZED "Build with optimization for speed (only in release build)" ON)
 option(BUILD_SHARED_LIBS "Build shared libraries for libnoise" ON)
 option(BUILD_LIBNOISE_DOCUMENTATION "Create doxygen documentation for developers" OFF)
 option(BUILD_LIBNOISE_UTILS "Build utility functions for use with libnoise" ON)
@@ -15,6 +15,7 @@ option(BUILD_LIBNOISE_EXAMPLES "Build libnoise examples" ON)
 
 #----------------------------------------
 # enable all warnings
+# usually the library implementor needs to take care of those warnings and not the user of the lib
 if (BUILD_WALL)
 	if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 		message(STATUS "GNU - using build with all warnings enabled")
@@ -27,7 +28,8 @@ endif()
 
 #----------------------------------------
 # enable optimized compile settings
-if (BUILD_OPTIMIZED)
+# This cmake build by default (if not in developer mode; hence release build) will build with `-O3`
+if (BUILD_SPEED_OPTIMIZED AND CMAKE_BUILD_TYPE EQUAL "Release")
 	if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 		message(STATUS "GNU - using compiler optimization for speed")
 		add_compile_options(-O3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,26 +2,68 @@
 
 cmake_minimum_required(VERSION 3.0)
 
-set ( LIBNOISE_VERSION "1.0.0-cmake" )
+set(LIBNOISE_VERSION "1.0.0-cmake")
 
+#----------------------------------------
+# Provide an option for the user to select (default given; otherwhise pass -Doption=ON to cmake)
+option(BUILD_WALL "Build with all warnings enabled" OFF)
+option(BUILD_OPTIMIZED "Build with optimization for speed" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries for libnoise" ON)
 option(BUILD_LIBNOISE_DOCUMENTATION "Create doxygen documentation for developers" OFF)
 option(BUILD_LIBNOISE_UTILS "Build utility functions for use with libnoise" ON)
 option(BUILD_LIBNOISE_EXAMPLES "Build libnoise examples" ON)
 
-message(STATUS "CMAKE_INSTALL_BINDIR : " ${CMAKE_INSTALL_BINDIR})
-message(STATUS "CMAKE_INSTALL_LIBDIR : " ${CMAKE_INSTALL_LIBDIR})
+#----------------------------------------
+# enable all warnings
+if (BUILD_WALL)
+	if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+		message(STATUS "GNU - using build with all warnings enabled")
+		add_compile_options(-Wall -ansi -pedantic)
+	elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+		message(STATUS "MSVC - using build with all warnings enabled")
+		add_compile_options(/Wall)
+	endif()
+endif()
 
+#----------------------------------------
+# enable optimized compile settings
+if (BUILD_OPTIMIZED)
+	if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+		message(STATUS "GNU - using compiler optimization for speed")
+		add_compile_options(-O3)
+	elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+		message(STATUS "MSVC - using compiler optimization for speed")
+		add_compile_options(/Ox)
+	endif()
+endif()
+
+#----------------------------------------
+# src
 add_subdirectory(src)
 
+#----------------------------------------
+# docs
+if(BUILD_LIBNOISE_DOCUMENTATION)
+	add_subdirectory(doc) 
+endif()
+
+#----------------------------------------
+# noiseutils
 if (BUILD_LIBNOISE_UTILS)
 	add_subdirectory(noiseutils)
 endif()
 
-if (BUILD_LIBNOISE_EXAMPLES)
-	add_subdirectory(examples)
+#----------------------------------------
+# examples
+if (BUILD_LIBNOISE_EXAMPLES AND BUILD_LIBNOISE_UTILS)
+	add_subdirectory(examples) # examples also depend on noiseutils
+elseif (BUILD_LIBNOISE_EXAMPLES)
+	message(STATUS "examples depend on noiseutils - \
+		fix: pass option -DBUILD_SHARED_LIBS=ON to cmake")
 endif()
 
-add_subdirectory(doc)
 
-#add_subdirectory(samples)
+#----------------------------------------
+# unused variables passed by vcpkg
+message(STATUS "CMAKE_INSTALL_BINDIR : " ${CMAKE_INSTALL_BINDIR})
+message(STATUS "CMAKE_INSTALL_LIBDIR : " ${CMAKE_INSTALL_LIBDIR})

--- a/README.md
+++ b/README.md
@@ -47,14 +47,16 @@ make install
 Usage
 -----
 
-see examples for details but in general:
+If you want to use this library, there are two ways of doing this (see examples for further details):
 
- 1. you need to supply the library `-lnoise` to the linker
- 2. the includes to the compile with `-I /usr/include/noise`
+* Linker
 
-OR
+** 1. you need to supply the library `-lnoise` to the linker
+** 2. the includes to the compile with `-I /usr/include/noise`
 
-Use provided FindLibNoise.cmake
+* CMake
+
+** use the provided FindLibNoise.cmake
 
 A comment on performance
 ------------------------
@@ -63,10 +65,13 @@ Using compiler optimizations for libnoise is *strongly recommended*.  Using the
 unoptimized library is roughly a fifth as fast as using -O3 on my test
 computer.
 
-this cmake build by default (if not in developer mode) will build with `-O3`
-
+This cmake build by default (if not in developer mode; hence release build) will build with `-O3`
 
 see:
 CMAKE_BUILD_TYPE
 
 Type of build (Debug, Release, ...)
+
+If you want to disable optimizations, pass the following to the cmake arguments:
+```"-DBUILD_SPEED_OPTIMIZED=OFF"```
+

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ If you want to use this library, there are two ways of doing this (see examples 
 
 * Linker
 
-** 1. you need to supply the library `-lnoise` to the linker
-** 2. the includes to the compile with `-I /usr/include/noise`
+ 1. you need to supply the library `-lnoise` to the linker
+ 2. the includes to the compile with `-I /usr/include/noise`
 
 * CMake
 
-** use the provided FindLibNoise.cmake
+use the provided FindLibNoise.cmake
 
 A comment on performance
 ------------------------

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -5,51 +5,46 @@
 #  http://tobias.rautenkranz.ch/cmake/doxygen/
 # but it is hard to understand...
   
-IF (BUILD_LIBNOISE_DOCUMENTATION)
+find_package(Doxygen)
 
-FIND_PACKAGE(Doxygen)
+if(DOXYGEN_FOUND)
+	set(DOXYGEN_LANGUAGE "English" CACHE STRING "Language used by doxygen")
+	mark_as_advanced(DOXYGEN_LANGUAGE)
 
-IF(DOXYGEN_FOUND)
-  SET(DOXYGEN_LANGUAGE "English" CACHE STRING "Language used by doxygen")
-  MARK_AS_ADVANCED(DOXYGEN_LANGUAGE)
+	# you could also set the version with this, see Doxygen.in
+	# there you will find a line like this: 
+	#      PROJECT_NUMBER         = @LIBNOISE_VERSION@
+	# @LIBNOISE_VERSION@ is then replaced by our global LIBNOISE_VERSION
+	#
+	# for instance you could uncomment the next 3 lines and change the version for testing
+	# SET(LIBNOISE_VERSION
+	#     "1.2.3-foo500"
+	# )
 
-  # you could also set the version with this, see Doxygen.in
-  # there you will find a line like this: 
-  #      PROJECT_NUMBER         = @LIBNOISE_VERSION@
-  # @LIBNOISE_VERSION@ is then replaced by our global LIBNOISE_VERSION
-  #
-  # for instance you could uncomment the next 3 lines and change the version for testing
-  # SET(LIBNOISE_VERSION
-  #     "1.2.3-foo500"
-  # )
+	# doxygen can reference external images with IMAGE_PATH, this is how we set it dynamically
+	set( CMAKE_DOXYGEN_IMAGE_PATH
+	"${CMAKE_CURRENT_SOURCE_DIR}/img"
+	)
 
-  # doxygen can reference external images with IMAGE_PATH, this is how we set it dynamically
-  SET( CMAKE_DOXYGEN_IMAGE_PATH
-    "${CMAKE_CURRENT_SOURCE_DIR}/img"
-  )
+	# doxygen searches for source code (defined in FILE_PATTERNS, for example: *.cpp *.h)
+	# with DOXYGEN_SOURCE_DIR we fill a list of directories and later we write it into
+	# the Doxyfile with a REGEX REPLACE (see below)
+	set( DOXYGEN_SOURCE_DIR
+	"${CMAKE_SOURCE_DIR}/src"
+	)
 
-  # doxygen searches for source code (defined in FILE_PATTERNS, for example: *.cpp *.h)
-  # with DOXYGEN_SOURCE_DIR we fill a list of directories and later we write it into
-  # the Doxyfile with a REGEX REPLACE (see below)
-  SET( DOXYGEN_SOURCE_DIR
-    "${CMAKE_SOURCE_DIR}/src"
-  )
+	set(DOXYGEN_OUTPUT_DIR html)
+	string(REGEX REPLACE ";" " " CMAKE_DOXYGEN_INPUT_LIST "${DOXYGEN_SOURCE_DIR}")
 
-  SET(DOXYGEN_OUTPUT_DIR html)
-  STRING(REGEX REPLACE ";" " " CMAKE_DOXYGEN_INPUT_LIST "${DOXYGEN_SOURCE_DIR}")
+	configure_file(Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+	set(HTML_TARGET "html" )
 
-  CONFIGURE_FILE(Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
-  SET(HTML_TARGET "html" )
+	add_custom_target(${HTML_TARGET} ALL
+	${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 
-  ADD_CUSTOM_TARGET(${HTML_TARGET} ALL
-		${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+	install( DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html/" DESTINATION "/usr/share/doc/libnoise-${LIBNOISE_VERSION}" )
 
-  INSTALL( DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html/" DESTINATION "/usr/share/doc/libnoise-${LIBNOISE_VERSION}" )
-
-ELSE(DOXYGEN_FOUND)
-  MESSAGE (FATAL_ERROR "doxygen binary couldn't be found")
-ENDIF(DOXYGEN_FOUND)
-
-ENDIF (BUILD_LIBNOISE_DOCUMENTATION)
-
+else(DOXYGEN_FOUND)
+	message (FATAL_ERROR "doxygen binary couldn't be found")
+endif(DOXYGEN_FOUND)

--- a/noiseutils/CMakeLists.txt
+++ b/noiseutils/CMakeLists.txt
@@ -1,36 +1,41 @@
 set(PROJECT_NAME libnoiseutils)
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS YES CACHE BOOL "Export all symbols")
-set(libSrcs ${libSrcs}
-	noiseutils.cpp
-)
-add_library(noiseutils SHARED ${libSrcs})
-add_library(noiseutils-static STATIC ${libSrcs})
+set(LIB_NAME noiseutils)
+message(STATUS "\n\n#############################################")
+message(STATUS "# building project ${PROJECT_NAME}")
 
-set_target_properties(noiseutils PROPERTIES LIBNOISE_VERSION ${LIBNOISE_VERSION})
-set_target_properties(noiseutils-static PROPERTIES LIBNOISE_VERSION ${LIBNOISE_VERSION})
+set(libSrcs ${libSrcs} noiseutils.cpp)
 
-target_link_libraries(noiseutils noise)
-target_link_libraries(noiseutils-static noise-static)
 
-# I would like to see more projects using these defaults
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-	message(STATUS "noiseutils - using optimized compile settings with all warnings enabled")
-	add_compile_options(-Wall -ansi -pedantic -O3)
-elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-	message(STATUS "noiseutils - using optimized compile settings with all warnings enabled")
-	add_compile_options(/Wall /Ox)
+if(BUILD_SHARED_LIBS)
+	#----------------------------------------
+	# build dynamic lib
+	set(TARGET_NAME "${LIB_NAME}")
+	add_library(${TARGET_NAME} SHARED ${libSrcs})
+	
+	if(WIN32)
+		#set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS YES CACHE BOOL "Export all symbols")
+		set_target_properties(${TARGET_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
+	endif() 
+	
+	set_target_properties(${TARGET_NAME} PROPERTIES VERSION ${LIBNOISE_VERSION})
+	target_link_libraries(${TARGET_NAME} noise)
+	target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+	
+	# install dynamic libraries (.dll or .so) into /bin
+	install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 endif()
 
-# Where to look for noise headers
-target_include_directories( noiseutils PRIVATE ${PROJECT_SOURCE_DIR}/src )
-target_include_directories( noiseutils-static PRIVATE ${PROJECT_SOURCE_DIR}/src )
+#----------------------------------------
+# build static lib (it's good practice to include a lib file for the dll)
+set(TARGET_NAME "${LIB_NAME}-static")
+add_library(${TARGET_NAME} STATIC ${libSrcs})
+set_target_properties(${TARGET_NAME} PROPERTIES VERSION ${LIBNOISE_VERSION})
+target_link_libraries(${TARGET_NAME} noise-static) 
+target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src) 
+# install static libraries (.lib) into /lib
+install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
+#----------------------------------------
 
 # install include files into /include
 install( FILES "${PROJECT_SOURCE_DIR}/noiseutils/noiseutils.h" 
 		DESTINATION "${CMAKE_INSTALL_PREFIX}/include/noise" )
-
-# install dynamic libraries (.dll or .so) into /bin
-install( TARGETS noiseutils DESTINATION "${CMAKE_INSTALL_PREFIX}/bin" )
-
-# install static libraries (.lib) into /lib
-install( TARGETS noiseutils-static DESTINATION "${CMAKE_INSTALL_PREFIX}/lib" )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,9 @@
-# http://www.linux-magazin.de/Heft-Abo/Ausgaben/2007/02/Mal-ausspannen
-
 set(PROJECT_NAME libnoise)
+set(LIB_NAME noise)
+message(STATUS "\n\n#############################################")
+message(STATUS "# building project ${PROJECT_NAME}")
 
-include_directories (noise)
+include_directories(noise)
 
 set(libSrcs ${libSrcs}
     noisegen.cpp
@@ -44,42 +45,38 @@ set(libSrcs ${libSrcs}
     module/voronoi.cpp
 )
 
-IF(BUILD_SHARED_LIBS)
-    IF (WIN32)
-		message(STATUS "build - shared for win32 (x86)")
-		add_library( noise SHARED ${libSrcs} win32/dllmain.cpp)
-    ELSE()
-		message(STATUS "build - shared for others")
-		add_library( noise SHARED ${libSrcs} )
-    ENDIF()
-ENDIF()
-
-add_library( noise-static STATIC ${libSrcs} )
-
-# this value is set in the root CMakeLists.txt
-set_target_properties( noise PROPERTIES LIBNOISE_VERSION ${LIBNOISE_VERSION} )
-set_target_properties( noise-static PROPERTIES LIBNOISE_VERSION ${LIBNOISE_VERSION} )
-
-target_compile_definitions( noise PRIVATE NOISE_BUILD_DLL)
-target_compile_definitions( noise-static PUBLIC NOISE_STATIC)
-
-set_target_properties( noise-static PROPERTIES OUTPUT_NAME "noise" )
-
-# I would like to see more projects using these defaults
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-	message(STATUS "noiseutils - using optimized compile settings with all warnings enabled")
-	add_compile_options(-Wall -ansi -pedantic -O3)
-elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-	message(STATUS "noiseutils - using optimized compile settings with all warnings enabled")
-	add_compile_options(/Wall /Ox)
+# Users of your library should be able to choose static library or shared library to build. 
+# Do not specify a library type explicitly unless necessary.
+if(BUILD_SHARED_LIBS)
+	#----------------------------------------
+	# build dynamic lib
+	set(TARGET_NAME "${LIB_NAME}")
+    if (WIN32)
+		message(STATUS "build ${TARGET_NAME}: shared | platform: win32 (x86) & win64 (x64)")
+		add_library(${TARGET_NAME} SHARED ${libSrcs} win32/dllmain.cpp)
+		set_target_properties(${TARGET_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
+    else()
+		message(STATUS "build ${TARGET_NAME}: shared | platform: others")
+		add_library(${TARGET_NAME} SHARED ${libSrcs})
+    endif()
+	set_target_properties(${TARGET_NAME} PROPERTIES VERSION ${LIBNOISE_VERSION})
+	target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+	target_compile_definitions(${TARGET_NAME} PRIVATE NOISE_BUILD_DLL)
+	install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 endif()
 
-# install include files into /include
-install( DIRECTORY "${PROJECT_SOURCE_DIR}/src/noise" 
-		DESTINATION "${CMAKE_INSTALL_PREFIX}/include" )
-
-# install dynamic libraries (.dll or .so) into /bin
-install( TARGETS noise DESTINATION "${CMAKE_INSTALL_PREFIX}/bin" )
-
+#----------------------------------------
+# build static lib (it's good practice to include a lib file for the dll)
+set(TARGET_NAME "${LIB_NAME}-static")
+message(STATUS "build ${TARGET_NAME}")
+add_library(${TARGET_NAME} STATIC ${libSrcs})
+set_target_properties(${TARGET_NAME} PROPERTIES VERSION ${LIBNOISE_VERSION})
+target_include_directories(${TARGET_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_compile_definitions(${TARGET_NAME} PUBLIC NOISE_STATIC)
 # install static libraries (.lib) into /lib
-install( TARGETS noise-static DESTINATION "${CMAKE_INSTALL_PREFIX}/lib" )
+install(TARGETS ${TARGET_NAME} DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
+#----------------------------------------
+
+# install include files into /include
+install( DIRECTORY   "${PROJECT_SOURCE_DIR}/src/noise" 
+		 DESTINATION "${CMAKE_INSTALL_PREFIX}/include" )


### PR DESCRIPTION
Hey

I found some bug under a certain condition. When you want to build for only static libraries the compiler says that it cannot find the target noise (which is the .dll or .so).
fix:

- the target and further cmake commands for it are put together now only for shared builds (BUILD_SHARED_LIBS==TRUE)

Another little bug which just occured to me under windows with MSVC compiler. That is when you are in debug build and are using the compile flag /Ox (-O3). This combination is not possible and the compiler sees that as an error:
fix:

- the optimization -O3 wasn't removed. it's just only enabled on RELEASE-builds. Which is also described inside the README now.

Also the following:

- Little refactorings like common lowercase ensured
- Wall is disabled by default. Unless you are working inside of libnoise, to fix some bugs, you should enable that. I wouldn't like it myself when some library verbositly throws warnings like "size_t not compatible with int" at me. Without me being able to fix those without touching the library.

I hope those changes are fine for you.